### PR TITLE
Minimum cut-off

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -8,6 +8,9 @@ namespace DvMod.SteamCutoff
         public const float TemperatureGaugeGamma = 0.4f;
 
         public const float CutoffGamma = 1.9f;
+        public const float MinCutoff = 0.06f;
+        public const float MaxCutoff = 0.85f;
+
         public const float InjectorGamma = 4f;
     }
 }

--- a/CylinderSimulation.cs
+++ b/CylinderSimulation.cs
@@ -6,8 +6,8 @@ namespace DvMod.SteamCutoff
     {
         public const float CylinderVolume = 282f; // PRR L1s: 27x30"
         public static float SteamChestPressure(SteamLocoSimulation sim) => sim.boilerPressure.value * sim.regulator.value;
-        public static float Cutoff(SteamLocoSimulation sim) => Mathf.Pow(sim.cutoff.value, Constants.CutoffGamma) * 0.85f;
-
+        public static float Cutoff(SteamLocoSimulation sim) => 
+            Mathf.Max(Constants.MinCutoff, Mathf.Pow(sim.cutoff.value, Constants.CutoffGamma) * Constants.MaxCutoff);
         // 4 strokes / revolution
         // 4.4m driver circumference (see ChuffController)
         // ~909 strokes / km

--- a/SteamCutoff.cs
+++ b/SteamCutoff.cs
@@ -283,7 +283,7 @@ namespace DvMod.SteamCutoff
                     return false;
 
                 var loco = __instance.GetComponent<TrainCar>();
-                float cutoff = Mathf.Pow(__instance.cutoff.value, Constants.CutoffGamma) * 0.85f;
+                float cutoff = CylinderSimulation.Cutoff(__instance);
                 if (cutoff > 0)
                 {
                     float boilerPressureRatio =


### PR DESCRIPTION
In walschaerts valve gear, the piston valve is driven not only by engineer-controlled reversing lever, but also via union link by the piston itself. Since union link is non-adjustable and always on, the piston valve will continue to rock slightly even if reversing lever is in neutral, hence minimum cut-off.