### PR TITLE
Support for different number of cylinders, CCL chuff controller fixes

### DIFF
--- a/ChuffAdapter.cs
+++ b/ChuffAdapter.cs
@@ -38,8 +38,8 @@ namespace DvMod.SteamCutoff
         }
 
         public float DriverCircumference => chuff.wheelCircumference;
-        public float CurrentRevolution => chuff.revolutionPos / chuff.wheelCircumference;
-        public float RotationSpeed => chuff.driverAnimation.defaultRotationSpeed / 2f / Mathf.PI;
+        public float CurrentRevolution => chuff.revolutionPos;
+        public float RotationSpeed => chuff.driverAnimation.defaultRotationSpeed;
         public float ChuffPower { set => chuff.chuffPower = value; }
     }
 }

--- a/CylinderSimulation.cs
+++ b/CylinderSimulation.cs
@@ -41,7 +41,7 @@ namespace DvMod.SteamCutoff
             float rotation,
             ExtraState state)
         {
-            var (pistonPosition, isFrontActive, crankOffset) = PistonLinearPosition(cylinder, totalCylinders: 2, rotation);
+            var (pistonPosition, isFrontActive, crankOffset) = PistonLinearPosition(cylinder, state.NumCylinders, rotation);
             ref bool intakeHasSteam = ref state.IsCylinderPressurized(cylinder, isFrontActive);
             ref bool exhaustHasSteam = ref state.IsCylinderPressurized(cylinder, !isFrontActive);
 
@@ -85,9 +85,9 @@ namespace DvMod.SteamCutoff
             ExtraState extraState)
         {
             float totalPower = 0f;
-            for (int cylinder = 0; cylinder < ExtraState.NumCylinders; cylinder++)
+            for (int cylinder = 0; cylinder < extraState.NumCylinders; cylinder++)
                 totalPower += InstantaneousCylinderPowerRatio(cutoff, maxExpansionRatio, cylinder, rotation, extraState);
-            return totalPower / ExtraState.NumCylinders;
+            return totalPower / extraState.NumCylinders;
         }
 
         public static float PowerRatio(float regulator, float cutoff, float revolution,

--- a/ExtraState.cs
+++ b/ExtraState.cs
@@ -24,17 +24,22 @@ namespace DvMod.SteamCutoff
             this.boilerState = new BoilerSimulation(sim, car);
             this.controlState = new ControlState();
             this.fireState = new FireState(sim);
+
+            this.NumCylinders = sim.NumCylinders;
+
+            this.cylinderFrontHasPressure = new bool[NumCylinders];
+            this.cylinderRearHasPressure = new bool[NumCylinders];
         }
 
-        public const int NumCylinders = 2;
+        public readonly int NumCylinders = 2;
 
         public readonly BoilerSimulation boilerState;
         public readonly ControlState controlState;
         public readonly FireState fireState;
         public float powerVel;
         // <summary>Whether a chamber (front/back of cylinder) has been pressurized.</summary>
-        public bool[] cylinderFrontHasPressure = new bool[NumCylinders];
-        public bool[] cylinderRearHasPressure = new bool[NumCylinders];
+        public bool[] cylinderFrontHasPressure;
+        public bool[] cylinderRearHasPressure;
         public ref bool IsCylinderPressurized(int cylinder, bool isFront)
         {
             return ref (isFront ? cylinderFrontHasPressure : cylinderRearHasPressure)[cylinder];

--- a/SimAdapter.cs
+++ b/SimAdapter.cs
@@ -36,6 +36,7 @@ namespace DvMod.SteamCutoff
         float SteamConsumptionMultiplier { get; }
         float TimeMult { get; }
         float PressureLeakMultiplier { get; set; }
+        int NumCylinders { get; }
     }
 
     public static class SimAdapter
@@ -121,6 +122,8 @@ namespace DvMod.SteamCutoff
             get => baseSim.pressureLeakMultiplier;
             set => baseSim.pressureLeakMultiplier = value;
         }
+
+        public int NumCylinders => 2;
     }
 
     public class CustomSimAdapter : ISimAdapter
@@ -176,5 +179,7 @@ namespace DvMod.SteamCutoff
             get => customSim.pressureLeakMultiplier;
             set => customSim.pressureLeakMultiplier = value;
         }
+
+        public int NumCylinders => customSim.simParams.NumberOfCylinders;
     }
 }


### PR DESCRIPTION
- CCL 1.7 changed wheel revolution position & speed to be normalized to revs / second instead of edge speed & distance
- change ExtraState's NumCylinders from a constant to a field that is pulled from loco sim